### PR TITLE
#296: implemented cache for token validation 

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -52,6 +52,7 @@
     <truth.version>0.28</truth.version>
     <vertx.version>3.4.1</vertx.version>
     <jmeter.version>3.2</jmeter.version>
+    <guava.version>23.0</guava.version>
   </properties>
 
   <dependencyManagement>
@@ -282,6 +283,11 @@
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-dispatch-router</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/core/src/main/java/org/eclipse/hono/config/SignatureSupportingConfigProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/SignatureSupportingConfigProperties.java
@@ -24,6 +24,7 @@ public class SignatureSupportingConfigProperties {
     private String keyPath;
     private long tokenExpirationSeconds = 600L;
     private String certificatePath;
+    private long validationCacheMaxSize = 100_000L;
 
     /**
      * Gets the secret used for creating and validating HmacSHA256 based signatures.
@@ -136,4 +137,13 @@ public class SignatureSupportingConfigProperties {
         return sharedSecret != null || certificatePath != null;
     }
 
+    /**
+     * Gets the maximum number of entries the validation cache may contain.
+     * This directly reflects the performance of registration token validation.
+     *
+     * @return number of maximum entries the validation cache can store
+     */
+    public long getValidationCacheMaxSize() {
+        return validationCacheMaxSize;
+    }
 }

--- a/core/src/main/java/org/eclipse/hono/util/JwtHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/JwtHelper.java
@@ -23,7 +23,13 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.hono.config.KeyLoader;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
 import io.vertx.core.Vertx;
 
 /**
@@ -47,6 +53,17 @@ public abstract class JwtHelper {
      * The lifetime of created tokens.
      */
     protected Duration tokenLifetime;
+
+    /**
+     * see {@link JwtParser#setAllowedClockSkewSeconds}
+     */
+    protected int allowedClockSkew = 10;
+
+    /**
+     * Specifies the maximum number of entries the validation cache may contain.
+     * This directly reflects the performance of registration token validation.
+     */
+    protected Long validationCacheMaxSize;
 
     /**
      * Creates a new helper for a vertx instance.
@@ -198,5 +215,20 @@ public abstract class JwtHelper {
         } else {
             return result.get();
         }
+    }
+
+    /**
+     * Sets the maximum number of entries the validation cache may contain.
+     * This directly reflects the performance of registration token validation.
+     *
+     * @param validationCacheMaxSize number of cache entries
+     * @throws IllegalArgumentException if the given max cache size is negative
+     */
+    public void setValidationCacheMaxSize(Long validationCacheMaxSize) {
+        Objects.requireNonNull(validationCacheMaxSize);
+        if (validationCacheMaxSize < 0L) {
+            throw new IllegalArgumentException("Validation cache size must not be negative.");
+        }
+        this.validationCacheMaxSize = validationCacheMaxSize;
     }
 }

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -92,6 +92,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/AuthTokenHelperImpl.java
@@ -62,6 +62,7 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
         } else {
             AuthTokenHelperImpl result = new AuthTokenHelperImpl(vertx);
             result.tokenLifetime = Duration.ofSeconds(config.getTokenExpiration());
+            result.setValidationCacheMaxSize(config.getValidationCacheMaxSize());
             if (config.getSharedSecret() != null) {
                 byte[] secret = getBytes(config.getSharedSecret());
                 result.setSharedSecret(secret);
@@ -89,6 +90,7 @@ public class AuthTokenHelperImpl extends JwtHelper implements AuthTokenHelper {
             throw new IllegalArgumentException("configuration does not specify any key material for validating signatures");
         } else {
             AuthTokenHelperImpl result = new AuthTokenHelperImpl(vertx);
+            result.setValidationCacheMaxSize(config.getValidationCacheMaxSize());
             if (config.getSharedSecret() != null) {
                 byte[] secret = getBytes(config.getSharedSecret());
                 result.setSharedSecret(secret);

--- a/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionCacheKey.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/registration/RegistrationAssertionCacheKey.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * Contributors:
+ * Bosch Software Innovations GmbH - initial creation
+ */
+package org.eclipse.hono.service.registration;
+
+/**
+ * A utility class for creating cache keys
+ */
+public final class RegistrationAssertionCacheKey {
+
+    /**
+     * The token representing the asserted status.
+     */
+    private final String token;
+
+    /**
+     * The tenant that the device is expected to belong to.
+     */
+    private final String tenantId;
+
+    /**
+     * The device that is expected to be the subject of the assertion.
+     */
+    private final String deviceId;
+
+    /**
+     * Key for validation cache (which is used to improve registration assertion validations) consisting of token,
+     * tenantId and deviceId
+     * @param token token, which is part of the cache key
+     * @param tenantId tenantId, which is part of the cache key
+     * @param deviceId deviceId, which is part of the cache key
+     */
+    RegistrationAssertionCacheKey(String token, String tenantId, String deviceId) {
+        this.token = token;
+        this.tenantId = tenantId;
+        this.deviceId = deviceId;
+    }
+
+    /**
+     * Getter method for token
+     *
+     * @return token
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * Getter method for tenantId
+     *
+     * @return tenantId
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Getter method for deviceId
+     *
+     * @return deviceId
+     */
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RegistrationAssertionCacheKey that = (RegistrationAssertionCacheKey) o;
+
+        return token.equals(that.token) && tenantId.equals(that.tenantId) && deviceId.equals(that.deviceId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = token.hashCode();
+        result = 31 * result + tenantId.hashCode();
+        result = 31 * result + deviceId.hashCode();
+        return result;
+    }
+}

--- a/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImplTest.java
+++ b/service-base/src/test/java/org/eclipse/hono/service/registration/RegistrationAssertionHelperImplTest.java
@@ -1,28 +1,38 @@
 /**
  * Copyright (c) 2017 Bosch Software Innovations GmbH.
- *
+ * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * <p>
  * Contributors:
- *    Bosch Software Innovations GmbH - initial creation
+ * Bosch Software Innovations GmbH - initial creation
  */
 
 package org.eclipse.hono.service.registration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.security.PrivateKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.config.KeyLoader;
 import org.eclipse.hono.config.SignatureSupportingConfigProperties;
 import org.junit.Test;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.vertx.core.Vertx;
 
 
 /**
  * Tests verifying behavior of {@link RegistrationAssertionHelperImpl}.
- *
  */
 public class RegistrationAssertionHelperImplTest {
 
@@ -35,7 +45,7 @@ public class RegistrationAssertionHelperImplTest {
     public void testForSigningRejectsShortSecret() {
 
         String shortSecret = "01234567890123456"; // not 32 bytes long
-        RegistrationAssertionHelperImpl.forSharedSecret(shortSecret, 10);
+        RegistrationAssertionHelperImpl.forSharedSecret(shortSecret, 10, 100_000L);
     }
 
     /**
@@ -53,7 +63,87 @@ public class RegistrationAssertionHelperImplTest {
         assertNotNull(assertion);
         RegistrationAssertionHelper validator = RegistrationAssertionHelperImpl.forValidating(vertx, props);
         assertTrue(validator.isValid(assertion, "tenant", "device"));
-
     }
 
+    /**
+     * Verifies that bad tenant, bad token and bad device are detected.
+     */
+    @Test
+    public void testTokenConsistency() {
+        RegistrationAssertionHelper validator = createValidator();
+
+        String token = createToken(1, "tenant", "device");
+        assertNotNull(token);
+        assertFalse(validator.isValid(token, "bad-tenant", "device"));
+        assertFalse(validator.isValid(token, "tenant", "bad-device"));
+
+        String badToken = createToken(1, "another-tenant", "device");
+        assertNotNull(badToken);
+        assertFalse(validator.isValid(badToken, "tenant", "device"));
+    }
+
+    /**
+     * Verifies that expired token is detected
+     */
+    @Test
+    public void testValidatingAlreadyExpiredTokens() {
+        RegistrationAssertionHelper validator = createValidator();
+
+        String tokenStillValid = createToken(1, "tenant", "device");
+        assertTrue(validator.isValid(tokenStillValid, "tenant", "device"));
+
+        String tokenTooOld = createToken(-1, "tenant", "device");
+        assertFalse(validator.isValid(tokenTooOld, "tenant", "device"));
+    }
+
+    /**
+     * Verifies that cache is used
+     */
+    @Test
+    public void testValidationIsUsingCache() {
+        String token = createToken(1, "tenant", "device");
+
+        long firstValidationParsed = getDurationOfValidation(token);
+        long secondValidationCached = getDurationOfValidation(token);
+
+        // ensure that cached validation is at least twice as fast as parsed validation
+        assertTrue((secondValidationCached * 2) < firstValidationParsed);
+    }
+
+    private long getDurationOfValidation(String token) {
+        RegistrationAssertionHelper validator = createValidator();
+        Instant before = Instant.now();
+        assertTrue(validator.isValid(token, "tenant", "device"));
+        Instant after = Instant.now();
+        long result = TimeUnit.NANOSECONDS.toMillis(Duration.between(before, after).getNano());
+        System.out.println("Validation took " + result + " ms");
+        return result;
+    }
+
+    private RegistrationAssertionHelper createValidator() {
+        SignatureSupportingConfigProperties props = new SignatureSupportingConfigProperties();
+        props.setKeyPath("target/certs/hono-messaging-key.pem");
+        props.setCertPath("target/certs/hono-messaging-cert.pem");
+
+        return RegistrationAssertionHelperImpl.forValidating(vertx, props);
+    }
+
+    private String createToken(int validForSeconds, String tenant, String device) {
+
+        PrivateKey key = KeyLoader.fromFiles(vertx, "target/certs/hono-messaging-key.pem", null).getPrivateKey();
+        SignatureAlgorithm algorithm = SignatureAlgorithm.RS256;
+
+        // considering default clock skew
+        int allowedClockSkew = 10;
+        if (validForSeconds <= 0) {
+            validForSeconds -= allowedClockSkew;
+        }
+
+        return Jwts.builder()
+                .signWith(algorithm, key)
+                .setSubject(device)
+                .claim("ten", tenant)
+                .setExpiration(Date.from(Instant.now().plus(Duration.ofSeconds(validForSeconds))))
+                .compact();
+    }
 }

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/MessageForwardingEndpointTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/MessageForwardingEndpointTest.java
@@ -11,20 +11,24 @@
  */
 package org.eclipse.hono.messaging;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.messaging.DownstreamAdapter;
-import org.eclipse.hono.messaging.ErrorConditions;
-import org.eclipse.hono.messaging.MessageForwardingEndpoint;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.MessageHelper;
@@ -238,6 +242,6 @@ public class MessageForwardingEndpointTest {
 
     private String getToken(final String secret, final String tenantId, final String deviceId) {
 
-        return RegistrationAssertionHelperImpl.forSharedSecret(secret, 10).getAssertion(tenantId, deviceId);
+        return RegistrationAssertionHelperImpl.forSharedSecret(secret, 10, 100_000L).getAssertion(tenantId, deviceId);
     }
 }

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneEventApiTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneEventApiTest.java
@@ -27,12 +27,12 @@ import org.eclipse.hono.client.HonoClient;
 import org.eclipse.hono.client.MessageSender;
 import org.eclipse.hono.client.impl.HonoClientImpl;
 import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilder;
-import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.event.impl.EventEndpoint;
 import org.eclipse.hono.service.auth.HonoSaslAuthenticatorFactory;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.EventConstants;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -80,7 +80,7 @@ public class StandaloneEventApiTest {
     @BeforeClass
     public static void prepareHonoServer(final TestContext ctx) {
 
-        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10);
+        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10, 100_000L);
         downstreamAdapter = new MessageDiscardingDownstreamAdapter(vertx);
         server = new HonoMessaging();
         server.setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx, TestSupport.createAuthenticationService(createUser())));

--- a/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneTelemetryApiTest.java
+++ b/services/messaging/src/test/java/org/eclipse/hono/messaging/StandaloneTelemetryApiTest.java
@@ -27,9 +27,9 @@ import org.eclipse.hono.connection.ConnectionFactoryImpl.ConnectionFactoryBuilde
 import org.eclipse.hono.service.auth.HonoSaslAuthenticatorFactory;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelper;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
-import org.eclipse.hono.util.TelemetryConstants;
 import org.eclipse.hono.telemetry.impl.TelemetryEndpoint;
 import org.eclipse.hono.util.Constants;
+import org.eclipse.hono.util.TelemetryConstants;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -71,7 +71,7 @@ public class StandaloneTelemetryApiTest {
     @BeforeClass
     public static void prepareHonoServer(final TestContext ctx) throws Exception {
 
-        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10);
+        assertionHelper = RegistrationAssertionHelperImpl.forSharedSecret(SECRET, 10, 100_000L);
         telemetryAdapter = new MessageDiscardingDownstreamAdapter(vertx);
         server = new HonoMessaging();
         server.setSaslAuthenticatorFactory(new HonoSaslAuthenticatorFactory(vertx, TestSupport.createAuthenticationService(createUser())));


### PR DESCRIPTION
- implemented cache for token validation
- default max cache size is 100.000 entries (configurable in SignatureSupportingConfigProperties.java)
- using guava loading cache implementation, entries will be auto removed X seconds after insertion (X = configured token life time)
- cache key consists of parameters of RegistrationAssertionHelper#isValid method (token, tenant, device)
- separate validation of expiration date, because besides auto-remove-feature, token can be stored slightly longer than configured token life time
- added unit tests

Also authored by:  Ulrich Overdieck <fixed-term.Ulrich.Overdieck@bosch-si.com>
Signed-off-by: Oliver Fischer <oliver.fischer@bosch-si.com>