### PR TITLE
#296: implemented cache for token validation

### DIFF
--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Config.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/Config.java
@@ -15,7 +15,7 @@ package org.eclipse.hono.adapter.mqtt;
 
 import org.eclipse.hono.config.ApplicationConfigProperties;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.AbstractAdapterConfig;
 import org.springframework.beans.factory.config.ObjectFactoryCreatingFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -69,8 +69,8 @@ public class Config extends AbstractAdapterConfig {
      */
     @Bean
     @ConfigurationProperties(prefix = "hono.mqtt")
-    public MqttProtocolAdapterProperties adapterProperties() {
-        return new MqttProtocolAdapterProperties();
+    public ProtocolAdapterProperties adapterProperties() {
+        return new ProtocolAdapterProperties();
     }
 
     /**

--- a/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
+++ b/adapters/mqtt-vertx/src/main/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapter.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.eclipse.hono.adapter.mqtt.credentials.MqttUsernamePassword;
 import org.eclipse.hono.client.MessageSender;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.service.AbstractProtocolAdapterBase;
 import org.eclipse.hono.service.registration.RegistrationAssertionHelperImpl;
 import org.eclipse.hono.util.Constants;
@@ -40,7 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * A Vert.x based Hono protocol adapter for accessing Hono's Telemetry API using MQTT.
  */
-public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<MqttProtocolAdapterProperties> {
+public class VertxBasedMqttProtocolAdapter extends AbstractProtocolAdapterBase<ProtocolAdapterProperties> {
 
     private static final Logger LOG = LoggerFactory.getLogger(VertxBasedMqttProtocolAdapter.class);
 

--- a/adapters/mqtt-vertx/src/test/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapterTest.java
+++ b/adapters/mqtt-vertx/src/test/java/org/eclipse/hono/adapter/mqtt/VertxBasedMqttProtocolAdapterTest.java
@@ -16,27 +16,21 @@ import static org.mockito.Mockito.*;
 
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.vertx.core.*;
-import io.vertx.core.eventbus.EventBus;
 import io.vertx.mqtt.MqttAuth;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttServer;
-import org.eclipse.hono.adapter.mqtt.credentials.MqttUsernamePassword;
-import org.eclipse.hono.client.CredentialsClient;
 import org.eclipse.hono.client.HonoClient;
-import org.eclipse.hono.config.ServiceConfigProperties;
+import org.eclipse.hono.config.ProtocolAdapterProperties;
 import org.eclipse.hono.util.Constants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.vertx.core.http.HttpServer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.ext.web.Router;
 import io.vertx.proton.ProtonClientOptions;
-import org.mockito.Mock;
 
 /**
  * Verifies behavior of {@link VertxBasedMqttProtocolAdapter}.
@@ -51,7 +45,7 @@ public class VertxBasedMqttProtocolAdapterTest {
     HonoClient registrationClient;
     HonoClient credentialsClient;
 
-    MqttProtocolAdapterProperties config;
+    ProtocolAdapterProperties config;
 
     private Vertx vertx;
 
@@ -74,7 +68,7 @@ public class VertxBasedMqttProtocolAdapterTest {
         messagingClient = mock(HonoClient.class);
         registrationClient = mock(HonoClient.class);
         credentialsClient = mock(HonoClient.class);
-        config = new MqttProtocolAdapterProperties();
+        config = new ProtocolAdapterProperties();
         config.setInsecurePortEnabled(true);
     }
 
@@ -226,7 +220,7 @@ public class VertxBasedMqttProtocolAdapterTest {
     private VertxBasedMqttProtocolAdapter getAdapter(final MqttServer server) {
         VertxBasedMqttProtocolAdapter adapter = new VertxBasedMqttProtocolAdapter() {
             @Override
-            public void setConfig(final MqttProtocolAdapterProperties configuration) {
+            public void setConfig(final ProtocolAdapterProperties configuration) {
                 setSpecificConfig(configuration);
             }
         };

--- a/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
+++ b/core/src/main/java/org/eclipse/hono/config/ProtocolAdapterProperties.java
@@ -10,20 +10,18 @@
  *    Bosch Software Innovations GmbH - initial creation
  */
 
-package org.eclipse.hono.adapter.mqtt;
-
-import org.eclipse.hono.config.ServiceConfigProperties;
+package org.eclipse.hono.config;
 
 /**
- * Configuration properties for the MQTT protocol adapter of Hono.
+ * Common configuration properties for protocol adapters of Hono.
  *
  */
-public class MqttProtocolAdapterProperties extends ServiceConfigProperties {
+public class ProtocolAdapterProperties extends ServiceConfigProperties {
 
     private boolean authenticationRequired = true;
 
     /**
-     * Checks whether the MQTT protocol adapter always authenticates devices using their provided credentials as defined
+     * Checks whether the protocol adapter always authenticates devices using their provided credentials as defined
      * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
      * <p>
      * If this property is {@code false} then devices are always allowed to publish data without providing
@@ -31,14 +29,14 @@ public class MqttProtocolAdapterProperties extends ServiceConfigProperties {
      * <p>
      * The default value of this property is {@code true}.
      *
-     * @return {@code true} if the MQTT protocol adapter demands the authentication of devices to allow the publishing of data.
+     * @return {@code true} if the protocol adapter demands the authentication of devices to allow the publishing of data.
      */
     public final boolean isAuthenticationRequired() {
         return authenticationRequired;
     }
 
     /**
-     * Sets whether the MQTT protocol adapter always authenticates devices using their provided credentials as defined
+     * Sets whether the protocol adapter always authenticates devices using their provided credentials as defined
      * in the <a href="https://www.eclipse.org/hono/api/Credentials-API/">Credentials API</a>.
      * <p>
      * If this property is set to {@code false} then devices are always allowed to publish data without providing

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -227,7 +227,7 @@ public final class MessageHelper {
     /**
      * Adds a registration assertion to an AMQP 1.0 message.
      * <p>
-     * The assertion is put to the message's <em>delivery-annotations</em> under key
+     * The assertion is put to the message's <em>application-properties</em> under key
      * {@link #APP_PROPERTY_REGISTRATION_ASSERTION}.
      * 
      * @param msg The message.

--- a/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
+++ b/jmeter/src/main/java/org/eclipse/hono/jmeter/client/HonoSender.java
@@ -31,6 +31,7 @@ import org.eclipse.hono.connection.ConnectionFactory;
 import org.eclipse.hono.connection.ConnectionFactoryImpl;
 import org.eclipse.hono.jmeter.HonoSampler;
 import org.eclipse.hono.jmeter.HonoSenderSampler;
+import org.eclipse.hono.util.RegistrationConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -303,7 +304,7 @@ public class HonoSender {
                 if (assertHandler.failed()) {
                     LOGGER.error("RegistrationClient.assertRegistration() failed", assertHandler.cause());
                 } else {
-                    token = assertHandler.result().getPayload().getString("assertion");
+                    token = assertHandler.result().getPayload().getString(RegistrationConstants.FIELD_ASSERTION);
                 }
                 latch.countDown();
             });

--- a/site/content/api/Telemetry-API.md
+++ b/site/content/api/Telemetry-API.md
@@ -51,11 +51,11 @@ The following table provides an overview of the properties a client needs to set
 | :------------- | :-------: | :----------------------- | :-------- | :---------- |
 | *content-type* | yes       | *properties*             | *symbol*  | SHOULD be set to *application/octet-stream* if the message payload is to be considered *opaque* binary data. In most cases though, the client should be able to set a more specific content type indicating the type and characteristics of the data contained in the payload, e.g. `text/plain; charset="utf-8"` for a text message or `application/json` etc. |
 | *device_id*    | yes       | *application-properties* | *string*  | MUST contain the ID of the device the data in the payload has been reported by. |
-| *assertion*    | yes       | *application-properties* | *string*  | A [JSON Web Token](https://jwt.io/introduction/) issued by the [Device Registration service]({{< relref "api/Device-Registration-API.md#assert-device-registration" >}}) asserting the device's registration status. |
+| *reg_assertion*| yes       | *application-properties* | *string*  | A [JSON Web Token](https://jwt.io/introduction/) issued by the [Device Registration service]({{< relref "api/Device-Registration-API.md#assert-device-registration" >}}) asserting the device's registration status. |
 
 The body of the message MUST consist of a single AMQP *Data* section containing the telemetry data. The format and encoding of the data MUST be indicated by the *content-type* and (optional) *content-encoding* properties of the message.
 
-Any additional properties set by the client in either the *properties* or *application-properties* sections are preserved by Hono, i.e. these properties will also be contained in the message delivered to consumers. However, the *assertion* contained in the *application-properties* will **not** be propagated downstream.
+Any additional properties set by the client in either the *properties* or *application-properties* sections are preserved by Hono, i.e. these properties will also be contained in the message delivered to consumers. However, the *reg_assertion* contained in the *application-properties* will **not** be propagated downstream.
 
 Note that Hono does not return any *application layer* message back to the client in order to signal the outcome of the operation. Instead, Hono signals reception of the message by means of the AMQP `ACCEPTED` outcome if the message complies with the formal requirements. Note that this does **not** mean that the telemetry message has been successfully forwarded to the AMQP 1.0 messaging network.
 

--- a/site/content/release-notes.md
+++ b/site/content/release-notes.md
@@ -8,7 +8,9 @@ weight = 800
 
 ### New Features
 
-* Metrics could be used in all services, now. New metrics from MQTT Adapter and REST Adapter are there and will be written to InfluxDB and shown in Grafana in the example deployment. 
+* Metrics could be used in all services, now. New metrics from MQTT Adapter and REST Adapter are there and will be written to InfluxDB and shown in Grafana in the example deployment.
+* The Credentials API is implemented and available as AMQP endpoint in the Device Registry component. The example deployment offers a file based implementation which implements the mandatory GET operation of the Credentials API. The optional parts are checked for valid parameters but are responded by the file based implementation with *not implemented*. This way the implementation of a production ready credentials store is eased, since only the defined methods need to be implemented by a Spring component (like the FileBasedCredentialsService class).
+* The MQTT adapter requires a username/password authentication by default now. The example file based credentials implementaion offers one documented combination of username/password ("sensor1"/"hono-secret") to use. Additionally, for special test scenarios the authentication of devices can be switched off in the MQTT adapter by configuration, in which case the adapter is open to all clients (like it was before). 
 
 ## 0.5-M8
 


### PR DESCRIPTION
- implemented cache for token validation
- default max cache size is 100.000 entries (configurable in SignatureSupportingConfigProperties.java)
- using guava loading cache implementation, entries will be auto removed X seconds after insertion (X = configured token life time)
- cache key consists of parameters of RegistrationAssertionHelper#isValid method (token, tenant, device)
- separate validation of expiration date, because besides auto-remove-feature, token can be stored slightly longer than configured token life time
- added unit tests

Also authored by: Ulrich Overdieck fixed-term.Ulrich.Overdieck@bosch-si.com
Signed-off-by: Oliver Fischer oliver.fischer@bosch-si.com