### PR TITLE
[#1679] Add Tenant backend, service, and configuration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,6 +30,7 @@
   <properties>
     <artemis.image.name>quay.io/enmasse/artemis-base:2.10.1</artemis.image.name>
     <assertj-core.version>3.13.2</assertj-core.version>
+    <mockito-inline.version>2.7.13</mockito-inline.version>
     <californium.version>2.1.0</californium.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.10.0</dispatch-router.image.name>
     <guava.version>28.0-jre</guava.version>
@@ -261,6 +262,12 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito-inline.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/services/device-registry-mongodb/pom.xml
+++ b/services/device-registry-mongodb/pom.xml
@@ -33,8 +33,25 @@
             <artifactId>hono-service-device-registry-base</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-service-base</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-mongo-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/Application.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/Application.java
@@ -36,6 +36,7 @@ import io.vertx.core.Verticle;
  * and <a href="https://www.eclipse.org/hono/docs/api/credentials/">Credentials API</a>.
  * </p>
  */
+@SuppressWarnings("unused")
 @ComponentScan(basePackages = "org.eclipse.hono.service.auth", excludeFilters = @ComponentScan.Filter(Deprecated.class))
 @ComponentScan(basePackages = "org.eclipse.hono.service.metric", excludeFilters = @ComponentScan.Filter(Deprecated.class))
 @ComponentScan(basePackages = "org.eclipse.hono.deviceregistry", excludeFilters = @ComponentScan.Filter(Deprecated.class))
@@ -53,6 +54,15 @@ public class Application extends AbstractBaseApplication {
      */
     private List<HealthCheckProvider> healthCheckProviders;
 
+    /**
+     * Starts the Device Registry Server.
+     *
+     * @param args command line arguments to pass to the server.
+     */
+    public static void main(final String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
     @Autowired
     public void setVerticles(final List<Verticle> verticles) {
         this.verticles = verticles;
@@ -68,8 +78,7 @@ public class Application extends AbstractBaseApplication {
 
         return super.deployVerticles().compose(ok -> {
 
-            @SuppressWarnings("rawtypes")
-            final List<Future> futures = new LinkedList<>();
+            @SuppressWarnings("rawtypes") final List<Future> futures = new LinkedList<>();
 
             for (final Verticle verticle : this.verticles) {
                 log.info("Deploying: {}", verticle);
@@ -95,14 +104,5 @@ public class Application extends AbstractBaseApplication {
             this.healthCheckProviders.forEach(this::registerHealthchecks);
             return Future.succeededFuture();
         });
-    }
-
-    /**
-     * Starts the Device Registry Server.
-     *
-     * @param args command line arguments to pass to the server.
-     */
-    public static void main(final String[] args) {
-        SpringApplication.run(Application.class, args);
     }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/ApplicationConfig.java
@@ -20,6 +20,7 @@ import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.config.VertxProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationService;
 import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
@@ -146,7 +147,7 @@ public class ApplicationConfig {
 
     /**
      * Creates a new instance of an AMQP 1.0 protocol handler for Hono's <em>Credentials</em> API.
-     * 
+     *
      * @return The handler.
      */
     @Bean
@@ -258,6 +259,17 @@ public class ApplicationConfig {
     @ConfigurationProperties(prefix = "hono.registry.svc")
     public MongoDbBasedRegistrationConfigProperties serviceProperties() {
         return new MongoDbBasedRegistrationConfigProperties();
+    }
+
+    /**
+     * Gets properties for the hono tenant mongodb service.
+     *
+     * @return The properties.
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "hono.tenant.svc")
+    public MongoDbBasedTenantsConfigProperties tenantsProperties() {
+        return new MongoDbBasedTenantsConfigProperties();
     }
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/MongoDbBasedDeviceBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/MongoDbBasedDeviceBackend.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb;
+
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedCredentialsService;
+import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedRegistrationService;
+import org.eclipse.hono.service.management.Id;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.credentials.CommonCredential;
+import org.eclipse.hono.service.management.device.AutoProvisioningEnabledDeviceBackend;
+import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.util.CredentialsResult;
+import org.eclipse.hono.util.RegistrationResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import io.opentracing.Span;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Verticle;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * TODO.
+ */
+@Repository
+@Qualifier("backend")
+@ConditionalOnProperty(name = "hono.app.type", havingValue = "mongodb", matchIfMissing = true)
+public class MongoDbBasedDeviceBackend extends AbstractVerticle
+        implements AutoProvisioningEnabledDeviceBackend, Verticle {
+
+    private final MongoDbBasedCredentialsService credentialsService;
+    private final MongoDbBasedRegistrationService registrationService;
+
+    /**
+     * Create a new instance.
+     *
+     * @param registrationService an implementation of registration service.
+     * @param credentialsService  an implementation of credentials service.
+     */
+    @Autowired
+    public MongoDbBasedDeviceBackend(
+            @Qualifier("serviceImpl") final MongoDbBasedRegistrationService registrationService,
+            @Qualifier("serviceImpl") final MongoDbBasedCredentialsService credentialsService) {
+        this.registrationService = registrationService;
+        this.credentialsService = credentialsService;
+    }
+
+    @Override
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId, final Span span) {
+        return null;
+    }
+
+    @Override
+    public Future<CredentialsResult<JsonObject>> get(final String tenantId, final String type, final String authId,
+                                                     final JsonObject clientContext, final Span span) {
+        return null;
+    }
+
+    @Override
+    public Future<OperationResult<Void>> updateCredentials(final String tenantId, final String deviceId,
+                                                           final List<CommonCredential> credentials,
+                                                           final Optional<String> resourceVersion, final Span span) {
+        return null;
+    }
+
+    @Override
+    public Future<OperationResult<List<CommonCredential>>> readCredentials(final String tenantId, final String deviceId, final Span span) {
+        return null;
+    }
+
+    @Override
+    public Future<OperationResult<Id>> createDevice(final String tenantId, final Optional<String> deviceId, final Device device, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+
+        return registrationService.createDevice(tenantId, deviceId, device, span)
+                .compose(r -> {
+                    if (r.getStatus() != HttpURLConnection.HTTP_CREATED) {
+                        return Future.succeededFuture(r);
+                    }
+
+                    // now create the empty credentials set
+                    // pass on the original result
+                    return credentialsService.updateCredentials(tenantId, r.getPayload().getId(),
+                            Collections.emptyList(),
+                            Optional.empty(),
+                            span).map(r);
+                });
+    }
+
+    @Override
+    public Future<OperationResult<Device>> readDevice(final String tenantId, final String deviceId, final Span span) {
+        return registrationService.readDevice(tenantId, deviceId, span);
+    }
+
+    @Override
+    public Future<OperationResult<Id>> updateDevice(final String tenantId, final String deviceId, final Device device,
+                                                    final Optional<String> resourceVersion, final Span span) {
+        return registrationService.updateDevice(tenantId, deviceId, device, resourceVersion, span);
+    }
+
+    @Override
+    public Future<Result<Void>> deleteDevice(final String tenantId, final String deviceId,
+                                             final Optional<String> resourceVersion, final Span span) {
+        return registrationService.deleteDevice(tenantId, deviceId, resourceVersion, span);
+    }
+
+    @Override
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId) {
+        return registrationService.assertRegistration(tenantId, deviceId);
+    }
+
+    @Override
+    public Future<RegistrationResult> assertRegistration(final String tenantId, final String deviceId, final String gatewayId) {
+        return registrationService.assertRegistration(tenantId, deviceId, gatewayId);
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/MongoDbBasedTenantBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/MongoDbBasedTenantBackend.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb;
+
+import java.util.Optional;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedTenantService;
+import org.eclipse.hono.service.management.Id;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.service.management.tenant.TenantBackend;
+import org.eclipse.hono.util.TenantResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import io.opentracing.Span;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Verticle;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A tenant backend for a mongodb based of device registry.
+ */
+@Repository
+@Qualifier("backend")
+@ConditionalOnProperty(name = "hono.app.type", havingValue = "mongodb", matchIfMissing = true)
+public class MongoDbBasedTenantBackend extends AbstractVerticle
+        implements TenantBackend, Verticle {
+
+    private final MongoDbBasedTenantService tenantService;
+
+    /**
+     * Create a new instance.
+     *
+     * @param tenantService an implementation of tenant service.
+     */
+    @SuppressWarnings("unused")
+    @Autowired
+    public MongoDbBasedTenantBackend(
+            @Qualifier("serviceImpl") final MongoDbBasedTenantService tenantService) {
+        this.tenantService = tenantService;
+    }
+
+    @Override
+    public Future<OperationResult<Id>> createTenant(final Optional<String> tenantId, final Tenant tenantObj, final Span span) {
+        return tenantService.createTenant(tenantId, tenantObj, span);
+
+    }
+
+    @Override
+    public Future<OperationResult<Tenant>> readTenant(final String tenantId, final Span span) {
+        return tenantService.readTenant(tenantId, span);
+
+    }
+
+    @Override
+    public Future<OperationResult<Void>> updateTenant(final String tenantId, final Tenant tenantObj, final Optional<String> resourceVersion, final Span span) {
+        return tenantService.updateTenant(tenantId, tenantObj, resourceVersion, span);
+    }
+
+    @Override
+    public Future<Result<Void>> deleteTenant(final String tenantId, final Optional<String> resourceVersion, final Span span) {
+        return tenantService.deleteTenant(tenantId, resourceVersion, span);
+    }
+
+    @Override
+    public Future<TenantResult<JsonObject>> get(final String tenantId) {
+        return tenantService.get(tenantId);
+    }
+
+    @Override
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn) {
+        return tenantService.get(subjectDn);
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/MongoDbConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/MongoDbConfigProperties.java
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A POJO for configuring MongoDB properties used by the
+ * MongoDbBasedRegistrationService.
+ */
+@SuppressWarnings("unused")
+public class MongoDbConfigProperties {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDbConfigProperties.class);
+
+    private String host;
+    private int port = 0;
+    private String dbName;
+    private String username;
+    private String password;
+    private String connectionString;
+    private int serverSelectionTimeoutMS = 0;
+    private int connectTimeoutMS = 0;
+    private int createIndicesTimeoutMS = 3000;
+
+    /**
+     * Gets the name or literal IP address of the host the MongoDB instance is
+     * running on.
+     *
+     * @return host name
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the name or literal IP address of the host the MongoDB instance is
+     * running on.
+     *
+     * @param host host name or IP address
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setHost(final String host) {
+        this.host = host;
+        return this;
+    }
+
+    /**
+     * Gets the ports the MongoDB is listening on.
+     *
+     * @return port number
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Sets the ports the MongoDB is listening on.
+     *
+     * @param port port number
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setPort(final int port) {
+        this.port = port;
+        return this;
+    }
+
+    /**
+     * Gets the database name.
+     *
+     * @return database name
+     */
+    public String getDbName() {
+        return dbName;
+    }
+
+    /**
+     * Sets the database name.
+     *
+     * @param dbName database name
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setDbName(final String dbName) {
+        this.dbName = dbName;
+        return this;
+    }
+
+    /**
+     * Gets the user name used for authentication.
+     *
+     * @return user name
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Sets the user name used for authentication.
+     *
+     * @param username user name
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setUsername(final String username) {
+        this.username = username;
+        return this;
+    }
+
+    /**
+     * Gets the password used for authentication.
+     *
+     * @return password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Sets the password used for authentication.
+     *
+     * @param password the password
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setPassword(final String password) {
+        this.password = password;
+        return this;
+    }
+
+    /**
+     * Gets the connection string for the MongoDB client.
+     *
+     * @return connection string
+     */
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    /**
+     * Sets the connection string for the MongoDB client. If set, the connection
+     * string overrides the other connection settings. Format:
+     * mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+     *
+     * @param connectionString connection string
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setConnectionString(final String connectionString) {
+        this.connectionString = connectionString;
+        return this;
+    }
+
+    /**
+     * Gets the time in milliseconds that the mongo driver will wait to select a
+     * server for an operation before raising an error.
+     *
+     * @return time in milliseconds
+     */
+    public int getServerSelectionTimeout() {
+        return serverSelectionTimeoutMS;
+    }
+
+    /**
+     * Sets the time in milliseconds that the mongo driver will wait to select a
+     * server for an operation before raising an error.
+     *
+     * @param timeout timeout in milliseconds. Setting to zero means the default
+     *                value of Vert.x should be used.
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setServerSelectionTimeout(final int timeout) {
+        this.serverSelectionTimeoutMS = timeout;
+        return this;
+    }
+
+    /**
+     * Gets the time in milliseconds to attempt a connection before timing out.
+     *
+     * @return time in milliseconds
+     */
+    public int getConnectTimeout() {
+        return connectTimeoutMS;
+    }
+
+    /**
+     * Sets the time in milliseconds to attempt a connection before timing out.
+     *
+     * @param connectTimeout timeout in milliseconds. Setting to zero means the default
+     *                       value of Vert.x should be used.
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setConnectTimeout(final int connectTimeout) {
+        this.connectTimeoutMS = connectTimeout;
+        return this;
+    }
+
+    /**
+     * Gets the time in milliseconds to create indices during startup.
+     *
+     * @return time in milliseconds
+     */
+    public int getCreateIndicesTimeout() {
+        return createIndicesTimeoutMS;
+    }
+
+    /**
+     * Sets the time in milliseconds that the startup will try to create indices
+     * during startup.
+     *
+     * @param timeout timeout in milliseconds.
+     * @return This instance for setter chaining.
+     */
+    public MongoDbConfigProperties setCreateIndicesTimeout(final int timeout) {
+        this.createIndicesTimeoutMS = timeout;
+        return this;
+    }
+
+    /**
+     * Returns the properties of this instance in a JsonObject suitable for
+     * initializing a Vertx MongoClient object. Note: if the connectionString is
+     * set, it will override all other connection settings.
+     *
+     * @return MongoDB client config object
+     */
+    public JsonObject asMongoClientConfigJson() {
+        final JsonObject config = new JsonObject();
+        if (connectionString != null) {
+            config.put("connection_string", connectionString);
+
+            if (host != null || port != 0 || dbName != null || username != null || password != null
+                    || serverSelectionTimeoutMS > 0 || connectTimeoutMS > 0) {
+                LOG.warn(
+                        "asMongoClientConfigJson: connectionString is set, other connection properties will be ignored");
+            }
+        } else {
+            if (host != null) {
+                config.put("host", host);
+            }
+            if (port != 0) {
+                config.put("port", port);
+            }
+            if (dbName != null) {
+                config.put("db_name", dbName);
+            }
+            if (username != null) {
+                config.put("username", username);
+            }
+            if (password != null) {
+                config.put("password", password);
+            }
+            if (serverSelectionTimeoutMS > 0) {
+                config.put("serverSelectionTimeoutMS", serverSelectionTimeoutMS);
+            }
+            if (connectTimeoutMS > 0) {
+                config.put("connectTimeoutMS", connectTimeoutMS);
+            }
+        }
+        return config;
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/AbstractMongoDbBasedRegistryConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/AbstractMongoDbBasedRegistryConfigProperties.java
@@ -17,7 +17,9 @@ package org.eclipse.hono.deviceregistry.mongodb.config;
  * Common configuration properties for Mongodb based implementations of the APIs of Hono's device registry as own server.
  * <p>
  * This class is intended to be used as base class for property classes that configure a specific mongodb based API implementation.
+ * </p>
  */
+@SuppressWarnings("unused")
 public abstract class AbstractMongoDbBasedRegistryConfigProperties {
 
     /**

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedTenantsConfigProperties.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/config/MongoDbBasedTenantsConfigProperties.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.config;
+
+/**
+ * Configuration properties for Hono's device registry device API.
+ */
+public final class MongoDbBasedTenantsConfigProperties extends AbstractMongoDbBasedRegistryConfigProperties {
+
+    /**
+     * Default name of mongodb tenant collection.
+     */
+    private static final String DEFAULT_TENANTS_COLLECTION_NAME = "tenants";
+
+    @Override
+    protected String getDefaultCollectionName() {
+        return DEFAULT_TENANTS_COLLECTION_NAME;
+    }
+
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/BaseDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/BaseDto.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public abstract class BaseDto {
+public class BaseDto {
 
     @JsonProperty(value = RegistryManagementConstants.FIELD_VERSION, required = true)
     protected String version;

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/TenantDto.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/model/TenantDto.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.util.RegistryManagementConstants;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A versioned and dated wrapper class for {@link Tenant}.
+ */
+public final class TenantDto extends BaseDto {
+
+    @JsonProperty(value = RegistryManagementConstants.FIELD_PAYLOAD_TENANT_ID, required = true)
+    private String tenantId;
+    @JsonProperty(RegistryManagementConstants.FIELD_TENANT)
+    private Tenant tenant;
+
+    /**
+     * Creates a new empty tenant dto.
+     */
+    public TenantDto() {
+        // Explicit default constructor.
+    }
+
+    /**
+     * @param tenantId  The tenant id.
+     * @param version   The version of tenant to be sent as request header.
+     * @param tenant    The tenant.
+     * @param updatedOn The timestamp of creation.
+     */
+    public TenantDto(final String tenantId, final String version, final Tenant tenant, final Instant updatedOn) {
+        this.tenantId = tenantId;
+        this.version = version;
+        this.tenant = tenant;
+        this.updatedOn = updatedOn;
+    }
+
+    /**
+     * Gets the tenant id.
+     *
+     * @return the tenant id or {@code null} if none has been set.
+     */
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Sets the tenant id.
+     * <p>
+     * Have to be conflict free with present tenants.
+     *
+     * @param tenantId the tenant id.
+     * @throws NullPointerException if the tenantId is {@code null}.
+     */
+    public void setTenantId(final String tenantId) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+    }
+
+    /**
+     * Gets the {@link Tenant}.
+     *
+     * @return the tenant or {@code null} if none has been set.
+     */
+    public Tenant getTenant() {
+        return tenant;
+    }
+
+    /**
+     * Sets the {@link Tenant}.
+     *
+     * @param tenant the tenant.
+     */
+    public void setTenant(final Tenant tenant) {
+        this.tenant = tenant;
+    }
+
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedTenantService.java
@@ -1,0 +1,649 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.service;
+
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.model.TenantDto;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbDocumentBuilder;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbErrorHandler;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbServiceUtils;
+import org.eclipse.hono.deviceregistry.util.DeviceRegistryUtils;
+import org.eclipse.hono.deviceregistry.util.Versioned;
+import org.eclipse.hono.service.management.Id;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.Result;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.service.management.tenant.TenantManagementService;
+import org.eclipse.hono.service.tenant.TenantService;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.TenantConstants;
+import org.eclipse.hono.util.TenantResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import io.opentracing.Span;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.IndexOptions;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.MongoClientDeleteResult;
+
+/**
+ * A tenant service that uses a mongodb client to manage tenants.
+ * <p>
+ * On startup this adapter tries to find the tenant collection, if not found, it gets created.
+ */
+@SuppressWarnings("RedundantTypeArguments")
+@Component
+@Qualifier("serviceImpl")
+@ConditionalOnProperty(name = "hono.app.type", havingValue = "mongodb")
+public final class MongoDbBasedTenantService extends AbstractVerticle implements TenantService, TenantManagementService {
+
+    private static final Logger log = LoggerFactory.getLogger(MongoDbBasedTenantService.class);
+
+    private MongoDbCallExecutor mongoDbCallExecutor;
+    private MongoClient mongoClient;
+    private MongoDbBasedTenantsConfigProperties config;
+
+    /**
+     * Autowires the mongodb client.
+     *
+     * @param mongoDbCallExecutor the executor singleton
+     */
+    @Autowired
+    public void setExecutor(final MongoDbCallExecutor mongoDbCallExecutor) {
+        this.mongoDbCallExecutor = mongoDbCallExecutor;
+        this.mongoClient = this.mongoDbCallExecutor.getMongoClient();
+    }
+
+    public MongoDbBasedTenantsConfigProperties getConfig() {
+        return config;
+    }
+
+    /**
+     * Autowires the tenant config.
+     *
+     * @param configuration The tenant configuration
+     */
+    @Autowired
+    public void setConfig(final MongoDbBasedTenantsConfigProperties configuration) {
+        this.config = configuration;
+    }
+
+    /**
+     * Starts the service.
+     * <p>
+     * Finishes if a tenant collection is found and creates an indexed collection else.
+     * </P>
+     *
+     * @param startPromise the startup promise
+     */
+    @Override
+    public void start(final Promise<Void> startPromise) {
+        final Promise<List<String>> existingCollections = Promise.promise();
+        mongoClient.getCollections(existingCollections);
+        existingCollections.future()
+                .compose(successExistingCollections -> {
+                    if (successExistingCollections.contains(getConfig().getCollectionName())) {
+                        return Future.succeededFuture();
+                    } else {
+                        // create index & implicit collection
+                        return mongoDbCallExecutor.createCollectionIndex(getConfig().getCollectionName(),
+                                new JsonObject().put(TenantConstants.FIELD_PAYLOAD_TENANT_ID, 1).put(TenantConstants.FIELD_PAYLOAD_DEVICE_ID, 1),
+                                new IndexOptions().unique(true));
+                    }
+                })
+                .compose(success -> {
+                    if (getConfig().isModificationEnabled()) {
+                        log.info("persistence is disabled, will not save tenant identities to mongoDB.");
+                    }
+                    log.debug("startup complete");
+                    startPromise.complete();
+                    return Future.succeededFuture();
+                }).onFailure(reason -> {
+            log.error("Index creation failed", reason);
+            startPromise.fail(reason.toString());
+        });
+    }
+
+    /**
+     * Stops the service.
+     *
+     * @param stopPromise the shutdown promise
+     */
+    @Override
+    public void stop(final Promise<Void> stopPromise) {
+        this.mongoClient.close();
+        stopPromise.complete();
+    }
+
+    /**
+     * Updates data of a present tenant.
+     * <p>
+     * Tenant modification have to be enabled in {@link MongoDbBasedTenantsConfigProperties} or exits with {@code HttpURLConnection.HTTP_FORBIDDEN}.
+     * </p>
+     * <p>
+     * Provided version {@code resourceVersion} have to be empty or equal to the version of present tenant.
+     * A provided <em>certificate authority</em> must not be set in other tenants.
+     * </p>
+     *
+     * @param tenantId        The identifier of the tenant.
+     * @param tenantObj       The updated configuration information for the tenant (may be {@code null}).
+     * @param resourceVersion The identifier of the resource version to update.
+     * @param span            The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                        An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                        parent for any spans created in this method.
+     * @return Result of update operation: On success {@code HttpURLConnection.HTTP_NO_CONTENT}, http error codes else. {@code HttpURLConnection.HTTP_FORBIDDEN} if modification is disabled.
+     * @throws NullPointerException if {@code tenantId} or {@code tenantObj} are {@code null}.
+     */
+    @Override
+    public Future<OperationResult<Void>> updateTenant(final String tenantId, final Tenant tenantObj, final Optional<String> resourceVersion, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(tenantObj);
+
+        if (!getConfig().isModificationEnabled()) {
+            final String errorMsg = "Modification disabled for tenant service.";
+            TracingHelper.logError(span, errorMsg);
+            log.info(errorMsg);
+            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN));
+        }
+        return processUpdateTenant(tenantId, tenantObj, resourceVersion, span);
+    }
+
+    /**
+     * Updates data of a present tenant.
+     * <p>
+     * Provided version {@code resourceVersion} have to be empty or equal to the version of present tenant.
+     * A provided <em>certificate authority</em> must not be set in other tenants.
+     * </p>
+     *
+     * @param tenantId        The identifier of the tenant.
+     * @param tenantObj       The updated configuration information for the tenant (may be {@code null}).
+     * @param resourceVersion The identifier of the resource version to update.
+     * @param span            The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                        An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                        parent for any spans created in this method.
+     * @return Result of update operation: On success {@code HttpURLConnection.HTTP_NO_CONTENT}, http error codes else.
+     * @throws NullPointerException if {@code tenantId} or {@code tenantObj} are {@code null}.
+     */
+    private Future<OperationResult<Void>> processUpdateTenant(final String tenantId, final Tenant tenantObj, final Optional<String> resourceVersion, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(tenantObj);
+
+        final JsonObject tenantQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .document();
+        return MongoDbServiceUtils.isVersionEqualCurrentVersionOrNotSet(mongoClient, getConfig().getCollectionName(), tenantQuery, resourceVersion)
+                .compose(versionEqualsORNotSet -> {
+                    if (!versionEqualsORNotSet) {
+                        TracingHelper.logError(span, "Resource Version mismatch.");
+                        return Future.<OperationResult<Void>>succeededFuture(OperationResult.<Void>empty(HttpURLConnection.HTTP_PRECON_FAILED));
+                    }
+                    final Versioned<Tenant> newTenant = new Versioned<>(tenantObj);
+                    final TenantDto newTenantDto = new TenantDto(tenantId, newTenant.getVersion(), newTenant.getValue(), Instant.now());
+                    final Future<Map.Entry<String, Versioned<Tenant>>> conflictingTenant = newTenantDto.getTenant()
+                            .getTrustedCertificateAuthoritySubjectDNs()
+                            .stream()
+                            .map(this::getByCa)
+                            .filter(Objects::nonNull)
+                            .findFirst()
+                            .orElseGet(() -> Future.succeededFuture(null));
+                    return conflictingTenant.compose(conflictingTenantFound -> {
+                        if (conflictingTenantFound != null && !tenantId.equals(conflictingTenantFound.getKey())) {
+                            // we are trying to use the same CA as another tenant
+                            TracingHelper.logError(span, "Conflict : CA already used by an existing tenant.");
+                            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_CONFLICT));
+                        }
+                        final JsonObject newTenantDtoJson = JsonObject.mapFrom(newTenantDto);
+                        final Promise<JsonObject> tenantUpdated = Promise.promise();
+                        mongoClient.findOneAndReplace(getConfig().getCollectionName(), tenantQuery, newTenantDtoJson, tenantUpdated);
+                        return tenantUpdated.future().compose(successTenantUpdated -> {
+                            if (successTenantUpdated == null) {
+                                throw new NullPointerException("Entity not found.");
+                            }
+                            return Future.succeededFuture(OperationResult.ok(
+                                    HttpURLConnection.HTTP_NO_CONTENT,
+                                    null,
+                                    Optional.empty(),
+                                    Optional.of(newTenantDto.getVersion())
+                            ));
+                        });
+                    });
+                })
+                .recover(errorVersionEqualsORNotSet -> {
+                    TracingHelper.logError(span, String.format("Tenant [%s] not found.", tenantId));
+                    return Future.<OperationResult<Void>>succeededFuture(OperationResult.<Void>empty(HttpURLConnection.HTTP_NOT_FOUND));
+                });
+
+
+    }
+
+    /**
+     * Deletes a present tenant.
+     * <p>
+     * Tenant modification have to be enabled in {@link MongoDbBasedTenantsConfigProperties} or exits with {@code HttpURLConnection.HTTP_FORBIDDEN}.
+     * </p>
+     * <p>
+     * Provided version {@code resourceVersion} have to be empty or equal to the version of present tenant.
+     * </p>
+     *
+     * @param tenantId        The identifier of the tenant.
+     * @param resourceVersion The identifier of the resource version to delete.
+     * @param span            The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                        An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                        parent for any spans created in this method.
+     * @return Result of deletion operation: On success {@code HttpURLConnection.HTTP_NO_CONTENT}, http error codes else. {@code HttpURLConnection.HTTP_FORBIDDEN} if modification is disabled.
+     * @throws NullPointerException if {@code tenantId} or resourceVersion are {@code null}.
+     */
+    @Override
+    public Future<Result<Void>> deleteTenant(final String tenantId, final Optional<String> resourceVersion, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(resourceVersion);
+
+        if (!getConfig().isModificationEnabled()) {
+            final String errorMsg = "Modification disabled for tenant service.";
+            TracingHelper.logError(span, errorMsg);
+            log.info(errorMsg);
+            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN));
+        }
+        return processDeleteTenant(tenantId, resourceVersion, span);
+    }
+
+    /**
+     * Deletes a present tenant.
+     * <p>
+     * Provided version {@code resourceVersion} have to be empty or equal to the version of present tenant.
+     * </p>
+     *
+     * @param tenantId        The identifier of the tenant.
+     * @param resourceVersion The identifier of the resource version to delete.
+     * @param span            The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                        An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                        parent for any spans created in this method.
+     * @return Result of deletion operation: On success {@code HttpURLConnection.HTTP_NO_CONTENT}, http error codes else.
+     * @throws NullPointerException if {@code tenantId} or resourceVersion are {@code null}.
+     */
+    private Future<Result<Void>> processDeleteTenant(final String tenantId, final Optional<String> resourceVersion, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(resourceVersion);
+
+        final JsonObject tenantQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .document();
+
+        return MongoDbServiceUtils.isVersionEqualCurrentVersionOrNotSet(mongoClient, getConfig().getCollectionName(), tenantQuery, resourceVersion)
+                .compose(versionEqualsORNotSet -> {
+                    if (!versionEqualsORNotSet) {
+                        TracingHelper.logError(span, "Resource Version mismatch.");
+                        return Future.succeededFuture(Result.<Void>from(HttpURLConnection.HTTP_PRECON_FAILED));
+                    }
+                    final Promise<MongoClientDeleteResult> deleteTenant = Promise.promise();
+                    mongoClient.removeDocument(getConfig().getCollectionName(), tenantQuery, deleteTenant);
+                    return deleteTenant.future().compose(successDeleteTenant -> {
+                        if (successDeleteTenant.getRemovedCount() == 0) {
+                            throw new IllegalStateException("Entity not found.");
+                        } else if (successDeleteTenant.getRemovedCount() > 1) {
+                            TracingHelper.logError(span, String.format("Multiple have been deleted.", tenantId));
+                            return Future.succeededFuture(Result.<Void>from(HttpURLConnection.HTTP_INTERNAL_ERROR));
+                        }
+                        // if successDeleteTenant.getRemovedCount() == 1
+                        return Future.succeededFuture(Result.<Void>from(HttpURLConnection.HTTP_NO_CONTENT));
+                    });
+                })
+                .recover(errorVersionEqualsORNotSet -> {
+                    TracingHelper.logError(span, String.format("Tenant [%s] not found.", tenantId));
+                    return Future.succeededFuture(Result.<Void>from(HttpURLConnection.HTTP_NOT_FOUND));
+                });
+    }
+
+    /**
+     * Fetches a tenant by tenant id.
+     *
+     * @param tenantId The identifier of the tenant.
+     * @return Future TenantResult with {@code HttpURLConnection.HTTP_OK} if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     * @throws NullPointerException if {@code tenantId} is {@code null}.
+     */
+    @Override
+    public Future<TenantResult<JsonObject>> get(final String tenantId) {
+        Objects.requireNonNull(tenantId);
+
+        return get(tenantId, null);
+    }
+
+    /**
+     * Fetches a tenant by tenant id.
+     *
+     * @param tenantId The identifier of the tenant.
+     * @param span     The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                 An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                 parent for any spans created in this method.
+     * @return Future TenantResult with {@code HttpURLConnection.HTTP_OK} if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     * @throws NullPointerException if {@code tenantId} is {@code null}.
+     */
+    @Override
+    public Future<TenantResult<JsonObject>> get(final String tenantId, final Span span) {
+        Objects.requireNonNull(tenantId);
+
+        return readTenant(tenantId, span)
+                .compose(successTenantRead -> {
+                    if (successTenantRead.getStatus() != HttpURLConnection.HTTP_OK) {
+                        TracingHelper.logError(span, String.format("tenant [%s] not found.", tenantId));
+                        return Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+                    }
+                    return Future.succeededFuture(TenantResult.from(
+                            HttpURLConnection.HTTP_OK,
+                            DeviceRegistryUtils.convertTenant(tenantId, successTenantRead.getPayload(), true),
+                            DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())
+                    ));
+                });
+    }
+
+    /**
+     * Fetches a tenant by {@link X500Principal}.
+     *
+     * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
+     *                  that has been configured for the tenant.
+     * @return Future TenantResult with {@code HttpURLConnection.HTTP_OK} if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     * @throws NullPointerException if {@code subjectDn} is {@code null}.
+     */
+    @Override
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn) {
+        Objects.requireNonNull(subjectDn);
+
+        return get(subjectDn, null);
+    }
+
+    /**
+     * Fetches a tenant by {@link X500Principal}.
+     *
+     * @param subjectDn The <em>subject DN</em> of the trusted CA certificate
+     *                  that has been configured for the tenant.
+     * @param span      The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                  An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                  parent for any spans created in this method.
+     * @return Future TenantResult with {@code HttpURLConnection.HTTP_OK} if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     * @throws NullPointerException if {@code subjectDn} is {@code null}.
+     */
+    @Override
+    public Future<TenantResult<JsonObject>> get(final X500Principal subjectDn, final Span span) {
+        Objects.requireNonNull(subjectDn);
+
+        return getForCertificateAuthority(subjectDn, span);
+
+    }
+
+    /**
+     * Finds an existing tenant by the subject DN of its configured certificate authority.
+     *
+     * @param subjectDn the subject DN to find the tenant with.
+     * @param span      The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                  An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                  parent for any spans created in this method.
+     * @return Future TenantResult with {@code HttpURLConnection.HTTP_OK} if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     */
+    private Future<TenantResult<JsonObject>> getForCertificateAuthority(final X500Principal subjectDn, final Span span) {
+        if (subjectDn == null) {
+            TracingHelper.logError(span, "missing subject DN");
+            return Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_BAD_REQUEST));
+        } else {
+            final Future<Map.Entry<String, Versioned<Tenant>>> tenantsFound = getByCa(subjectDn);
+            return tenantsFound.compose(successTenantRead -> {
+                if (successTenantRead == null) {
+                    TracingHelper.logError(span, "no tenant found for subject DN");
+                    return Future.succeededFuture(TenantResult.from(HttpURLConnection.HTTP_NOT_FOUND));
+                } else {
+                    return Future.succeededFuture(TenantResult.from(
+                            HttpURLConnection.HTTP_OK,
+                            DeviceRegistryUtils.convertTenant(successTenantRead.getKey(), successTenantRead.getValue().getValue(), true),
+                            DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())));
+                }
+            });
+        }
+    }
+
+    /**
+     * Fetches tenant by subject DN.
+     *
+     * @param subjectDn the subject DN.
+     * @return A Future Map consisting of pair of a tenant id and a versioned tenant.
+     */
+    private Future<Map.Entry<String, Versioned<Tenant>>> getByCa(final X500Principal subjectDn) {
+
+        if (subjectDn == null) {
+            return Future.failedFuture("missing subject DN");
+        } else {
+            final JsonObject findTenantQuery = new MongoDbDocumentBuilder()
+                    .withCa("tenant", subjectDn.getName())
+                    .document();
+
+            final Promise<JsonObject> tenantsFound = Promise.promise();
+            mongoClient.findOne(getConfig().getCollectionName(), findTenantQuery, new JsonObject(), tenantsFound);
+            return tenantsFound.future().compose(successTenantsFound -> {
+                if (successTenantsFound == null || successTenantsFound.size() == 0) {
+                    return Future.succeededFuture(null);
+                }
+                final TenantDto tenantDtoFound = successTenantsFound.mapTo(TenantDto.class);
+                return Future.succeededFuture(
+                        new AbstractMap.SimpleEntry<>(tenantDtoFound.getTenantId(), new Versioned<>(tenantDtoFound.getVersion(), tenantDtoFound.getTenant()))
+                );
+            });
+        }
+    }
+
+    /**
+     * Retrieves a tenant by tenant id.
+     *
+     * @param tenantId The identifier of the tenant.
+     * @param span     The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                 An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                 parent for any spans created in this method.
+     * @return Result of find operation: On success {@code HttpURLConnection.HTTP_OK}, if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     * @throws NullPointerException if {@code tenantId} is {@code null}.
+     */
+    @Override
+    public Future<OperationResult<Tenant>> readTenant(final String tenantId, final Span span) {
+        Objects.requireNonNull(tenantId);
+
+        return processReadTenant(tenantId, span);
+    }
+
+    /**
+     * Retrieves a tenant by tenant id.
+     *
+     * @param tenantId The identifier of the tenant.
+     * @param span     The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                 An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                 parent for any spans created in this method.
+     * @return Result of find operation: On success {@code HttpURLConnection.HTTP_OK}, if tenant found, {@code HttpURLConnection.HTTP_NOT_FOUND} else.
+     * @throws NullPointerException if {@code tenantId} is {@code null}.
+     */
+    private Future<OperationResult<Tenant>> processReadTenant(final String tenantId, final Span span) {
+        Objects.requireNonNull(tenantId);
+
+        final JsonObject findTenantQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .document();
+        final Promise<JsonObject> didReadTenant = Promise.promise();
+        mongoClient.findOne(getConfig().getCollectionName(), findTenantQuery, new JsonObject(), didReadTenant);
+        //noinspection unchecked
+        return didReadTenant.future().compose(successDidReadTenant -> Optional.ofNullable(successDidReadTenant)
+                .map(tenantFound -> Future.succeededFuture(OperationResult.ok(
+                        HttpURLConnection.HTTP_OK,
+                        tenantFound.getJsonObject("tenant").mapTo(Tenant.class),
+                        Optional.ofNullable(DeviceRegistryUtils.getCacheDirective(config.getCacheMaxAge())),
+                        Optional.ofNullable(tenantFound.getString("version")))
+                )).orElseGet(() -> Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_NOT_FOUND))))
+                .recover(errorDidReadTenant -> MongoDbErrorHandler.operationFailed(log, span, "tenants could not be read."));
+    }
+
+    /**
+     * Checks if a given tenant id exists in db.
+     *
+     * @param tenantId the tenant id to check for.
+     * @return Future with {@code true} if the id already exist.
+     */
+    private Future<Boolean> tenantIdExist(final String tenantId) {
+        final JsonObject findTenantQuery = new MongoDbDocumentBuilder()
+                .withTenantId(tenantId)
+                .document();
+        final Promise<JsonObject> checkedIdExist = Promise.promise();
+        mongoClient.findOne(getConfig().getCollectionName(), findTenantQuery, new JsonObject(), checkedIdExist);
+        //noinspection unchecked
+        return checkedIdExist.future().compose(successCheckedIdExist -> Future.succeededFuture(successCheckedIdExist != null && !successCheckedIdExist.isEmpty()))
+                .recover(errorDidReadTenant -> MongoDbErrorHandler.operationFailed(log, null, "tenants could not be read."));
+    }
+
+    /**
+     * Generate a random tenant ID that is conflict free from existing tenant ids.
+     *
+     * @return a conflict free tenant id.
+     */
+    private Future<String> createConflictFreeUUID() {
+        final String id = UUID.randomUUID().toString();
+        return tenantIdExist(id).compose(successIdExist -> {
+            if (successIdExist) {
+                return createConflictFreeUUID();
+            } else {
+                return Future.succeededFuture(id);
+            }
+        });
+    }
+
+    /**
+     * Inserts a tenant into the device registry.
+     * <p>
+     * Tenant modification have to be enabled in {@link MongoDbBasedTenantsConfigProperties} or exits with {@code HttpURLConnection.HTTP_FORBIDDEN}.
+     * </p>
+     * <p>
+     * Optional: A tenant id can be provided. If none is set, a UUID will be created.
+     * A provided <em>certificate authority</em> must not be set in other tenants.
+     * </p>
+     *
+     * @param tenantId  The identifier of the tenant to create.
+     * @param tenantObj The configuration information to add for the tenant (may be {@code null}).
+     * @param span      The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                  An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                  parent for any spans created in this method.
+     * @return Result of insertion operation: On success {@code HttpURLConnection.HTTP_CREATED}, http error codes else. {@code HttpURLConnection.HTTP_FORBIDDEN} if modification is disabled.
+     * @throws NullPointerException if {@code tenantId} or {@code tenantObj} are {@code null}.
+     */
+    @Override
+    public Future<OperationResult<Id>> createTenant(final Optional<String> tenantId, final Tenant tenantObj, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(tenantObj);
+
+        if (!getConfig().isModificationEnabled()) {
+            final String errorMsg = "Modification disabled for tenant service.";
+            TracingHelper.logError(span, errorMsg);
+            log.info(errorMsg);
+            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_FORBIDDEN));
+        }
+        return processCreateTenant(tenantId, tenantObj, span);
+    }
+
+    /**
+     * Inserts a tenant into the device registry.
+     * <p>
+     * Optional: A tenant id can be provided. If none is set, a UUID will be created.
+     * A provided <em>certificate authority</em> must not be set in other tenants.
+     * </p>
+     *
+     * @param tenantId  The identifier of the tenant to create.
+     * @param tenantObj The configuration information to add for the tenant (may be {@code null}).
+     * @param span      The active OpenTracing span for this operation. It is not to be closed in this method!
+     *                  An implementation should log (error) events on this span and it may set tags and use this span as the
+     *                  parent for any spans created in this method.
+     * @return Result of insertion operation: On success {@code HttpURLConnection.HTTP_CREATED}, http error codes else.
+     * @throws NullPointerException if {@code tenantId} or {@code tenantObj} are {@code null}.
+     */
+    private Future<OperationResult<Id>> processCreateTenant(final Optional<String> tenantId, final Tenant tenantObj, final Span span) {
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(tenantObj);
+
+        final Future<String> getTenantId;
+        if (tenantId.isPresent()) {
+            getTenantId = Future.succeededFuture(tenantId.get());
+        } else {
+            getTenantId = createConflictFreeUUID();
+        }
+        return getTenantId
+                .compose(successTenantId -> {
+                    final Versioned<Tenant> newTenant = new Versioned<>(tenantObj);
+                    final TenantDto newTenantDto = new TenantDto(successTenantId, newTenant.getVersion(), newTenant.getValue(), Instant.now());
+                    if (newTenantDto.getVersion() == null) {
+                        TracingHelper.logError(span, "Tenant format invalid.");
+                        return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_BAD_REQUEST));
+                    }
+
+                    final Future<Map.Entry<String, Versioned<Tenant>>> conflictingTenant = newTenantDto.getTenant()
+                            .getTrustedCertificateAuthoritySubjectDNs()
+                            .stream()
+                            .map(this::getByCa)
+                            .filter(Objects::nonNull)
+                            .findFirst()
+                            .orElseGet(() -> Future.succeededFuture(null));
+
+                    return conflictingTenant.compose(conflictingTenantFound -> {
+                        if (conflictingTenantFound != null && !successTenantId.equals(conflictingTenantFound.getKey())) {
+                            // CA is already present in another tenant
+                            TracingHelper.logError(span, "Conflict : CA already used by an existing tenant.");
+                            return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_CONFLICT));
+                        }
+
+                        final JsonObject newTenantDtoJson = JsonObject.mapFrom(newTenantDto);
+                        final Promise<String> getTenantInsertion = Promise.promise();
+                        mongoClient.insert(getConfig().getCollectionName(), newTenantDtoJson, getTenantInsertion);
+                        return getTenantInsertion.future()
+                                .compose(successTenantInsertion -> Future.succeededFuture(OperationResult.ok(HttpURLConnection.HTTP_CREATED, Id.of(successTenantId), Optional.empty(), Optional.of(newTenant.getVersion()))))
+                                .recover(errorTenantInsertion -> {
+                                    if (MongoDbErrorHandler.ifDuplicateKeyError(errorTenantInsertion)) {
+                                        final var errorMsg = String.format("Tenant [%s] with id [%s] already exist.", newTenant.getValue(), successTenantId);
+                                        log.error(errorMsg);
+                                        TracingHelper.logError(span, errorMsg);
+                                        return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_CONFLICT));
+                                    } else {
+                                        final var errorMsg = String.format("Tenant [%s] could no be created.", newTenant.getValue());
+                                        log.error(errorMsg);
+                                        TracingHelper.logError(span, errorMsg);
+                                        return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_INTERNAL_ERROR));
+                                    }
+                                });
+                    });
+                })
+                .recover(errorTenantCreation -> {
+                    final var errorMsg = String.format("Tenant [%s] could no be created.", getTenantId.result());
+                    log.error(errorMsg);
+                    TracingHelper.logError(span, errorMsg);
+                    return Future.succeededFuture(OperationResult.empty(HttpURLConnection.HTTP_INTERNAL_ERROR));
+                });
+    }
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.hono.deviceregistry.mongodb.utils;
 
+import org.eclipse.hono.util.AuthenticationConstants;
 import org.eclipse.hono.util.RegistrationConstants;
+import org.eclipse.hono.util.RegistryManagementConstants;
 
 import io.vertx.core.json.JsonObject;
 
@@ -43,6 +45,21 @@ public final class MongoDbDocumentBuilder {
      */
     public MongoDbDocumentBuilder withDeviceId(final String deviceId) {
         document.put(RegistrationConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId);
+        return this;
+    }
+
+    /**
+     * Adds nested CA subjectDn property.
+     *
+     * @param entityPropKey key where entity properties are stored. e.g.: "tenant" for the {@link org.eclipse.hono.deviceregistry.mongodb.model.TenantDto}
+     * @param caSubjectDn   certificate Authority subjectDn
+     * @return a reference to this for fluent use.
+     */
+    public MongoDbDocumentBuilder withCa(final String entityPropKey, final String caSubjectDn) {
+        document.put(
+                String.format("%s.%s.%s", entityPropKey, RegistryManagementConstants.FIELD_PAYLOAD_TRUSTED_CA, AuthenticationConstants.FIELD_SUBJECT_DN),
+                new JsonObject().put("$eq", caSubjectDn)
+        );
         return this;
     }
 

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbErrorHandler.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbErrorHandler.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceregistry.mongodb.utils;
+
+import org.eclipse.hono.tracing.TracingHelper;
+import org.slf4j.Logger;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoException;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+
+/**
+ * Utility class for common error handling functions across device registry services.
+ */
+@SuppressWarnings("checkstyle:HideUtilityClassConstructor")
+public final class MongoDbErrorHandler {
+
+    /**
+     * Checks if a provided error is {@link MongoException} with error category {@link ErrorCategory#DUPLICATE_KEY}.
+     *
+     * @param throwable The exception to check. Other Throwables but {@link MongoException} return {@code false}.
+     * @return {@code true} if exception is an {@link ErrorCategory#DUPLICATE_KEY} exception.
+     */
+    public static boolean ifDuplicateKeyError(final Throwable throwable) {
+        if (throwable instanceof MongoException) {
+            final MongoException mongoException = (MongoException) throwable;
+            return ErrorCategory.fromErrorCode(mongoException.getCode()) == ErrorCategory.DUPLICATE_KEY;
+        }
+        return false;
+    }
+
+
+    /**
+     * A helper method to log error, log message and error on span and return a failed Future for error handling.
+     *
+     * @param log      current Logger
+     * @param span     tracer span, optional
+     * @param errorMsg the error message.
+     * @param error the thrown error to log on the span.
+     * @return Future error containing the message.
+     */
+    @SuppressWarnings("rawtypes")
+    public static Future operationFailed(final Logger log, final Span span, final String errorMsg, final Throwable error) {
+        log.error(errorMsg);
+        if (span != null) {
+            if (error != null) {
+                TracingHelper.logError(span, errorMsg, error);
+            } else {
+                TracingHelper.logError(span, errorMsg);
+            }
+        }
+        return Future.failedFuture(errorMsg);
+    }
+    /**
+     * A helper method to log error, log message on span and return a failed Future for error handling.
+     *
+     * @param log      current Logger
+     * @param span     tracer span, optional
+     * @param errorMsg the error message.
+     * @return Future error containing the message.
+     */
+    public static Future operationFailed(final Logger log, final Span span, final String errorMsg) {
+        return operationFailed(log, span, errorMsg, null);
+    }
+
+}

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbServiceUtils.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbServiceUtils.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.utils;
+
+import java.util.Optional;
+
+import org.eclipse.hono.deviceregistry.mongodb.model.BaseDto;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.MongoClient;
+
+@SuppressWarnings( {"checkstyle:MissingJavadocType", "checkstyle:HideUtilityClassConstructor"})
+/**
+ * Utility class for common functions across device registry services.
+ */
+public final class MongoDbServiceUtils {
+
+    /**
+     * Check if a Version is different or not set.
+     *
+     * @param expectedVersion new version, can unset
+     * @param actualValue     current version
+     * @return {@code true}, if different version or {@code expectedVersion} is unset
+     */
+    public static boolean isVersionDifferent(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") final Optional<String> expectedVersion, final String actualValue) {
+        return !actualValue.equals(expectedVersion.orElse(actualValue));
+    }
+
+    /**
+     * Checks if a given version is set and checks compares it to the version of
+     *  an {@link BaseDto} entity in the mongodb db found by a given collection and query.
+     * 
+     * @param mongoClient the mongodb client.
+     * @param collection  the mongo db collection to apply the query on.
+     * @param query       the query for a {@link BaseDto} JsonObject for version comparision.
+     * @param newVersion  the version to compare the queried {@link BaseDto} to. Can be null or {@code Optional.empty()}
+     * @return {@code true} if versions of given version and queried BaseDto are equal or no version given, {@code false} else.
+     * @throws NullPointerException if no entity could be found with the {@code query}.
+     */
+    public static Future<Boolean> isVersionEqualCurrentVersionOrNotSet(final MongoClient mongoClient, final String collection, final JsonObject query, final Optional<String> newVersion) {
+        if (newVersion == null || !newVersion.isPresent()) {
+            return Future.succeededFuture(true);
+        }
+        final Promise<JsonObject> currentVersionablePromise = Promise.promise();
+        mongoClient.findOne(collection, query, new JsonObject(), currentVersionablePromise);
+        return currentVersionablePromise.future()
+                .compose(currentVersionable -> {
+                    if (currentVersionable == null) {
+                        throw new NullPointerException("Entity not found.");
+                    }
+                    final BaseDto currentVersionableDto = currentVersionable.mapTo(BaseDto.class);
+                    if (MongoDbServiceUtils.isVersionDifferent(newVersion, currentVersionableDto.getVersion())) {
+                        return Future.succeededFuture(false);
+                    } else {
+                        return Future.succeededFuture(true);
+                    }
+                });
+    }
+}

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/services/MongoDbBasedTenantServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/services/MongoDbBasedTenantServiceTest.java
@@ -1,0 +1,444 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.deviceregistry.mongodb.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.model.TenantDto;
+import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedTenantService;
+import org.eclipse.hono.deviceregistry.mongodb.utils.MongoDbCallExecutor;
+import org.eclipse.hono.service.management.OperationResult;
+import org.eclipse.hono.service.management.tenant.Tenant;
+import org.eclipse.hono.service.management.tenant.TenantManagementService;
+import org.eclipse.hono.service.management.tenant.TrustedCertificateAuthority;
+import org.eclipse.hono.service.tenant.AbstractTenantServiceTest;
+import org.eclipse.hono.service.tenant.TenantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.stubbing.Answer;
+
+import com.mongodb.MongoException;
+
+import io.opentracing.Span;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.mongo.MongoClientDeleteResult;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(VertxExtension.class)
+@Timeout(timeUnit = TimeUnit.SECONDS, value = 3)
+class MongoDbBasedTenantServiceTest extends AbstractTenantServiceTest {
+
+    private static final List<Integer> DUPLICATE_KEY_ERROR_CODES = Arrays.asList(11000, 11001, 12582);
+    private final String DUMMY_TENANT_ID = "dummyTenantId";
+    private MongoDbBasedTenantsConfigProperties config;
+    private TenantDto DUMMY_TENANT_DTO;
+    private MongoDbCallExecutor mongoDbCallExecutor;
+    private MongoClient mongoClient;
+    private MongoDbBasedTenantService svc;
+
+    @BeforeEach
+    void setUp() {
+        final Context ctx = mock(Context.class);
+        final Vertx vertx = mock(Vertx.class);
+        config = new MongoDbBasedTenantsConfigProperties();
+        DUMMY_TENANT_DTO = new TenantDto(DUMMY_TENANT_ID, "dummyVersion", new Tenant(), Instant.now());
+        svc = spy(new MongoDbBasedTenantService());
+        svc.setConfig(config);
+        svc.init(vertx, ctx);
+
+        mongoDbCallExecutor = mock(MongoDbCallExecutor.class);
+        mongoClient = mock(MongoClient.class);
+        when(mongoDbCallExecutor.getMongoClient()).thenReturn(mongoClient);
+        svc.setExecutor(mongoDbCallExecutor);
+
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(DUMMY_TENANT_DTO)));
+                    return null;
+                });
+        when(mongoClient.insert(anyString(), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<String>>) invocation.getArguments()[2];
+                    result.handle(Future.succeededFuture(DUMMY_TENANT_ID));
+                    return null;
+                });
+        when(mongoClient.removeDocument(anyString(), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<MongoClientDeleteResult>>) invocation.getArguments()[2];
+                    result.handle(Future.succeededFuture(new MongoClientDeleteResult(1)));
+                    return null;
+                });
+        when(mongoClient.findOneAndReplace(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(DUMMY_TENANT_DTO)));
+                    return null;
+                });
+
+
+    }
+
+    @Override
+    public TenantService getTenantService() {
+        return svc;
+    }
+
+    @Override
+    public TenantManagementService getTenantManagementService() {
+        return svc;
+    }
+
+    @Test
+    public void testDoStartHasTenantCollection(final VertxTestContext ctx) {
+
+        // GIVEN a tenant service with existing tenant db collection
+        when(mongoClient.getCollections(any(Handler.class))).thenAnswer(
+                invocation -> {
+                    final var result = (Handler<AsyncResult<List<String>>>) invocation.getArguments()[0];
+                    result.handle(Future.succeededFuture(new ArrayList<>(Arrays.asList("dummyCollection1", config.getCollectionName()))));
+                    return null;
+                });
+        // THEN no new collection should be created
+        final Promise<Void> startupTracker = Promise.promise();
+        startupTracker.future().setHandler(ctx.succeeding(started -> ctx.verify(() -> {
+            verify(mongoDbCallExecutor, never()).createCollectionIndex(anyString(), any(JsonObject.class), any());
+            ctx.completeNow();
+        })));
+
+        // WHEN starting the service
+        svc.start(startupTracker);
+    }
+
+    @Test
+    public void testDoStartNoExistingTenantCollection(final VertxTestContext ctx) {
+
+        // GIVEN a tenant service without existing tenant collection
+        when(mongoClient.getCollections(any(Handler.class))).thenAnswer(
+                invocation -> {
+                    final var result = (Handler<AsyncResult<List<String>>>) invocation.getArguments()[0];
+                    result.handle(Future.succeededFuture(new ArrayList<>(Collections.singletonList("dummyCollection1"))));
+                    return null;
+                });
+        // GIVEN successful mongodb index creation
+        when(mongoDbCallExecutor.createCollectionIndex(anyString(), any(JsonObject.class), any()))
+                .thenReturn(Future.succeededFuture());
+
+        // THEN a new indexed collection should be created
+        final Promise<Void> startupTracker = Promise.promise();
+        startupTracker.future().setHandler(ctx.succeeding(started -> ctx.verify(() -> {
+            verify(mongoDbCallExecutor, atMostOnce()).createCollectionIndex(anyString(), any(JsonObject.class), any());
+            ctx.completeNow();
+        })));
+
+        // WHEN starting the service
+        svc.start(startupTracker);
+    }
+
+    @Test
+    public void testAddTenantSucceedsWithGivenTenantId(final VertxTestContext ctx) {
+
+        // WHEN tenant creation method called
+        svc.createTenant(Optional.of(DUMMY_TENANT_ID), new Tenant(), null)
+                // THEN a new tenant should be inserted and response should be HTTP_CREATED
+                .setHandler(ctx.succeeding(successCreatedTenant -> ctx.verify(() -> {
+                    assertThat(successCreatedTenant.getStatus()).isEqualTo(HttpURLConnection.HTTP_CREATED);
+                    ctx.completeNow();
+                })));
+
+
+    }
+
+    @Test
+    public void testGetTenantFailsForNonExistingTenant(final VertxTestContext ctx) {
+
+        // GIVEN tenant collection without a tenant with the dummy id
+        doAnswer((Answer<Void>) invocation -> {
+            final var result = (Handler<Future<JsonObject>>) invocation.getArguments()[3];
+            result.handle(Future.succeededFuture());
+            return null;
+        }).when(mongoClient)
+                .findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class));
+
+        // WHEN tenant read method called
+        svc.readTenant(DUMMY_TENANT_ID, null)
+                // THEN no tenant should be found and HTTP_NOT_FOUND 404 should be returned
+                .setHandler(ctx.succeeding(successDidReadTenant -> ctx.verify(() -> {
+                    assertThat(successDidReadTenant.getStatus()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+                    ctx.completeNow();
+                })));
+    }
+
+    @Test
+    public void testGetTenantSucceedsForExistingTenant(final VertxTestContext ctx) {
+
+        // GIVEN a tenant db with an existing tenant
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(DUMMY_TENANT_DTO)));
+                    return null;
+                });
+        // WHEN existing tenant is requested
+        svc.readTenant(DUMMY_TENANT_ID, null)
+                // THEN a tenant should be found and returned
+                .setHandler(ctx.succeeding(successDidReadTenant -> ctx.verify(() -> {
+                    assertThat(successDidReadTenant.getStatus()).isEqualTo(HttpURLConnection.HTTP_OK);
+                    assertThat(successDidReadTenant.getPayload()).isInstanceOf(Tenant.class);
+                    ctx.completeNow();
+                })));
+
+    }
+
+    @Test
+    @Override
+    public void testAddTenantFailsForDuplicateCa(final VertxTestContext ctx) {
+
+        // GIVEN a successful create tenant mongodb response and one with a duplicate key error
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+
+                    result.handle(Future.succeededFuture(new JsonObject()));
+                    return null;
+                })
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+
+                    final Tenant tenant = new Tenant()
+                            .setTrustedCertificateAuthorities(List.of(new TrustedCertificateAuthority()
+                                    .setSubjectDn("CN=taken")
+                                    .setPublicKey("NOTAKEY".getBytes(StandardCharsets.UTF_8))
+                                    .setNotBefore(Instant.now().minus(1, ChronoUnit.DAYS))
+                                    .setNotAfter(Instant.now().plus(2, ChronoUnit.DAYS))));
+
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(
+                            new TenantDto("tenant", "dummyVersion", tenant, Instant.now())
+                    )));
+                    return null;
+                });
+
+        super.testAddTenantFailsForDuplicateCa(ctx);
+
+    }
+
+    @Override
+    @Test
+    public void testAddTenantFailsForDuplicateTenantId(final VertxTestContext ctx) {
+
+        when(mongoClient.insert(anyString(), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<String>>) invocation.getArguments()[2];
+                    result.handle(Future.succeededFuture(DUMMY_TENANT_ID));
+                    return null;
+                })
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<String>>) invocation.getArguments()[2];
+                    result.handle(Future.failedFuture(new MongoException(DUPLICATE_KEY_ERROR_CODES.get(0), "Duplicate tenantId dummyException")));
+                    return null;
+                });
+
+        super.testAddTenantFailsForDuplicateTenantId(ctx);
+    }
+
+    @Override
+    @Test
+    public void testAddTenantSucceedsWithGeneratedTenantId(final VertxTestContext ctx) {
+
+        // GIVEN first generated id found, second one free
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(new TenantDto(DUMMY_TENANT_ID, "dummyVersion", new Tenant(), Instant.now()))));
+                    return null;
+                })
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(new JsonObject()));
+                    return null;
+                });
+        super.testAddTenantSucceedsWithGeneratedTenantId(ctx);
+    }
+
+    @Override
+    @Test
+    public void testDeleteTenantWithMatchingResourceVersionSucceed(final VertxTestContext ctx) {
+
+        doReturn(Future.succeededFuture(
+                OperationResult.ok(HttpURLConnection.HTTP_CREATED, Optional.of(DUMMY_TENANT_DTO.getTenantId()), Optional.empty(), Optional.of(DUMMY_TENANT_DTO.getVersion()))
+        )).when(svc).createTenant(any(Optional.class), any(Tenant.class), any(Span.class));
+
+        super.testDeleteTenantWithMatchingResourceVersionSucceed(ctx);
+    }
+
+    @Override
+    @Test
+    public void testUpdateTenantSucceeds(final VertxTestContext ctx) {
+
+        doReturn(Future.succeededFuture(
+                OperationResult.ok(HttpURLConnection.HTTP_CREATED, Optional.of(DUMMY_TENANT_DTO.getTenantId()), Optional.empty(), Optional.of(DUMMY_TENANT_DTO.getVersion()))
+        )).when(svc).createTenant(any(Optional.class), any(Tenant.class), any(Span.class));
+
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                // GIVEN mongodb response to provide updateTenant a tenant with previous updated properties
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    final TenantDto updatedTenantDto = new TenantDto();
+                    final Tenant updatedTenant = DUMMY_TENANT_DTO.getTenant();
+                    final var extensionMap = new HashMap<String, Object>();
+                    extensionMap.put("custom-prop", "something");
+                    updatedTenant.setExtensions(extensionMap);
+                    updatedTenantDto.setTenant(updatedTenant);
+
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(updatedTenantDto)));
+                    return null;
+                });
+
+        super.testUpdateTenantSucceeds(ctx);
+    }
+
+    @Override
+    @Test
+    public void testRemoveTenantSucceeds(final VertxTestContext ctx) {
+
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(DUMMY_TENANT_DTO)));
+                    return null;
+                })
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture());
+                    return null;
+                });
+
+        super.testRemoveTenantSucceeds(ctx);
+    }
+
+    @Override
+    @Test
+    public void testUpdateTenantWithMatchingResourceVersionSucceeds(final VertxTestContext ctx) {
+
+        // GIVEN a tenant creation with a fixed version returned
+        doReturn(Future.succeededFuture(
+                OperationResult.ok(HttpURLConnection.HTTP_CREATED, Optional.of(DUMMY_TENANT_DTO.getTenantId()), Optional.empty(), Optional.of(DUMMY_TENANT_DTO.getVersion()))
+        )).when(svc).createTenant(any(Optional.class), any(Tenant.class), any(Span.class));
+
+        super.testDeleteTenantWithMatchingResourceVersionSucceed(ctx);
+    }
+
+    @Override
+    @Test
+    public void testGetForCertificateAuthoritySucceeds(final VertxTestContext ctx) {
+        // GIVEN a tenant with id "tenant" and TrustedCertificateAuthorities
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(new JsonObject()));
+                    return null;
+                })
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    final X500Principal subjectDn = new X500Principal("O=Eclipse, OU=Hono, CN=ca");
+
+                    final Tenant tenant = new Tenant()
+                            .setTrustedCertificateAuthorities(List.of(new TrustedCertificateAuthority()
+                                    .setSubjectDn(subjectDn)
+                                    .setPublicKey("NOTAPUBLICKEY".getBytes(StandardCharsets.UTF_8))
+                                    .setNotBefore(Instant.now().minus(1, ChronoUnit.DAYS))
+                                    .setNotAfter(Instant.now().plus(2, ChronoUnit.DAYS))));
+
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(
+                            new TenantDto("tenant", "dummyVersion", tenant, Instant.now())
+                    )));
+                    return null;
+                });
+
+        super.testGetForCertificateAuthoritySucceeds(ctx);
+    }
+
+    @Override
+    @Test
+    public void testGetForCertificateAuthorityFailsForUnknownSubjectDn(final VertxTestContext ctx) {
+
+        // GIVEN a tenant with id "tenant" and TrustedCertificateAuthorities
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+
+                    result.handle(Future.succeededFuture(new JsonObject()));
+                    return null;
+                });
+
+        super.testGetForCertificateAuthorityFailsForUnknownSubjectDn(ctx);
+    }
+
+    @Override
+    @Test
+    public void testUpdateTenantFailsForDuplicateCa(final VertxTestContext ctx) {
+
+        when(mongoClient.findOne(anyString(), any(JsonObject.class), any(JsonObject.class), any(Handler.class)))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+                    result.handle(Future.succeededFuture(new JsonObject()));
+                    return null;
+                })
+                .thenAnswer((Answer<Void>) invocation -> {
+                    final var result = (Handler<AsyncResult<JsonObject>>) invocation.getArguments()[3];
+
+                    final Tenant tenant = new Tenant()
+                            .setTrustedCertificateAuthorities(List.of(new TrustedCertificateAuthority()
+                                    .setSubjectDn("CN=taken")
+                                    .setPublicKey("NOTAKEY".getBytes(StandardCharsets.UTF_8))
+                                    .setNotBefore(Instant.now().minus(1, ChronoUnit.DAYS))
+                                    .setNotAfter(Instant.now().plus(2, ChronoUnit.DAYS))));
+
+                    result.handle(Future.succeededFuture(JsonObject.mapFrom(
+                            new TenantDto("tenant", "dummyVersion", tenant, Instant.now())
+                    )));
+                    return null;
+                });
+
+        super.testUpdateTenantFailsForDuplicateCa(ctx);
+    }
+
+
+}


### PR DESCRIPTION
- Add additional helper classes to extract common service functions.
- Add TenantDto to wrap Tenant class and extend it with Versioned class and timestamp
- Add Tests for Tenant service
- Add dep: org.mockito:mockito-inline in order to mock final class MongoDbCallExecutor

Signed-off-by: Jan Kostulski <jan.kostulski@bosch.io>